### PR TITLE
Handle telegram video notes

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -46,6 +46,7 @@ pub async fn command_handler(
             let welcome_text = "🎤 Welcome to the Speech-to-Text Bot!\n\n\
                 📝 Send me:\n\
                 • Voice messages\n\
+                • Video notes (round video messages)\n\
                 • Audio files (.mp3, .m4a, .ogg, etc.)\n\
                 • Video files (I'll extract the audio)\n\n\
                 I'll transcribe the speech and send you the text!";
@@ -100,7 +101,7 @@ pub async fn audio_handler(bot: Bot, msg: Message, config: BotConfig) -> Respons
             error!("Error processing audio: {}", e);
             let error_msg = match e {
                 BotError::Audio(audio::AudioError::UnsupportedFormat(_)) => {
-                    "❌ Unsupported audio format. Please send voice messages, audio files (.mp3, .m4a, .ogg), or video files."
+                    "❌ Unsupported audio format. Please send voice messages, video notes, audio files (.mp3, .m4a, .ogg), or video files."
                 }
                 BotError::Audio(audio::AudioError::ConversionFailed(_)) => {
                     "❌ Failed to process audio. The file might be corrupted or in an unsupported format."
@@ -139,6 +140,10 @@ async fn process_audio_message(bot: &Bot, msg: &Message, config: &BotConfig) -> 
                 teloxide::types::MediaKind::Video(video_msg) => {
                     info!("Processing video file: duration {}s", video_msg.video.duration);
                     (&video_msg.video.file, "video.mp4")
+                }
+                teloxide::types::MediaKind::VideoNote(video_note_msg) => {
+                    info!("Processing video note: duration {}s", video_note_msg.video_note.duration);
+                    (&video_note_msg.video_note.file, "video_note.mp4")
                 }
                 teloxide::types::MediaKind::Document(doc_msg) => {
                     info!("Processing document: {}", 

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ async fn main() -> Result<()> {
         .branch(
             Update::filter_message()
                 .chain(dptree::filter(|msg: Message| {
-                    msg.voice().is_some() || msg.audio().is_some() || msg.video().is_some()
+                    msg.voice().is_some() || msg.audio().is_some() || msg.video().is_some() || msg.video_note().is_some()
                 }))
                 .endpoint(handlers::audio_handler),
         );


### PR DESCRIPTION
Add support for Telegram video notes to allow the bot to process these messages.

Previously, the bot would log 'Unhandled update' for `VideoNote` messages because they were not explicitly filtered or processed, leading to a lack of functionality for this message type.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-f115c59c-f60f-424c-a6f1-1539676a619e) · [Cursor](https://cursor.com/background-agent?bcId=bc-f115c59c-f60f-424c-a6f1-1539676a619e)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)